### PR TITLE
Change main title position to relative

### DIFF
--- a/app/ilmoweb/static/CSS/main.css
+++ b/app/ilmoweb/static/CSS/main.css
@@ -27,7 +27,7 @@ body {
 }
 
 #main_title {
-    position: absolute;
+    position: relative;
     left: 67px;
     top: 80px;
 }


### PR DESCRIPTION
Change the main title position to relative in order to the title to be correctly positioned when the page is accessed e.g. with a mobile device. 