### PR TITLE
Fixed duplicate file upload

### DIFF
--- a/app/ilmoweb/logic/files.py
+++ b/app/ilmoweb/logic/files.py
@@ -1,14 +1,6 @@
 """Module for app logic."""
 from django.http import HttpResponse
 
-def save_file(file):
-    """
-        save file to filesystem
-    """
-    with open("ilmoweb/static/upload/" + file.name, "wb+") as destination:
-        for chunk in file.chunks():
-            destination.write(chunk)
-
 def download_file(filename):
     """
         download file from filesystem

--- a/app/ilmoweb/models.py
+++ b/app/ilmoweb/models.py
@@ -61,7 +61,7 @@ class Report(models.Model):
     student = models.ForeignKey(User, on_delete=models.CASCADE, related_name = "student")
     lab_group = models.ForeignKey(LabGroups, on_delete=models.CASCADE)
     send_date = models.DateField(auto_now_add=True)
-    filename = models.FileField(null=True)
+    filename = models.FileField(upload_to="ilmoweb/static/upload/", null=True)
     report_status = models.IntegerField()
     # 0 = no file, 1 = report returned, 2 = revisions proposed, 3 = fixed report, 4 = report graded
     comments = models.TextField()

--- a/app/ilmoweb/views.py
+++ b/app/ilmoweb/views.py
@@ -161,7 +161,6 @@ def return_report(request):
     lab_group = LabGroups.objects.get(pk=group_id)
     file = request.FILES["file"]
     if file.name.lower().endswith(('.pdf', '.docx')):
-        files.save_file(file)
         report = Report(student=request.user, lab_group=lab_group, filename=file, report_status=1)
         report.save()
     return redirect("/my_labs")


### PR DESCRIPTION
Files were uploaded to two different locations. Removed unnecessary function used in uploading as Django is able to do this without helper functions. 